### PR TITLE
Design: 상품 상세페이지 상단 UI

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,6 @@
   "semi": true,
   "useTabs": false,
   "tabWidth": 2,
-  "printWidth": 80,
+  "printWidth": 100,
   "arrowParens": "always"
 }

--- a/src/api/request.tsx
+++ b/src/api/request.tsx
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+// const baseURL = ''
+
+// 로그인 테스트
+export const requestLogin = async (id: string, pw: string) => {
+  try {
+    const url =
+      'https://abf630fa-517f-4e51-9dac-36cba71c3ecc.mock.pstmn.io/api/login';
+    const res = await axios.post(url, {
+      id,
+      pw,
+    });
+    console.log(res);
+  } catch (err) {
+    console.log('에러발생 : ', err);
+  }
+};

--- a/src/pages/Auth/SignIn.tsx
+++ b/src/pages/Auth/SignIn.tsx
@@ -5,6 +5,7 @@ import { Main, SubmitButton, Div, CategoryTitle } from './SignUp';
 import { useNavigate } from 'react-router-dom';
 import { IoMailOutline } from 'react-icons/io5';
 import { SlLock } from 'react-icons/sl';
+import { requestLogin } from '../../api/request';
 
 interface SigninForm {
   id: string;
@@ -30,7 +31,8 @@ const SignIn = () => {
         />
       </Div>
       <h1 style={{ padding: '30px 0 50px' }}>Login</h1>
-      <form onSubmit={handleSubmit((data) => alert(JSON.stringify(data)))}>
+      {/* <form onSubmit={handleSubmit((data) => alert(JSON.stringify(data)))}> */}
+      <form onSubmit={handleSubmit((data) => requestLogin(data.id, data.pw))}>
         <Div>
           <div>
             <CategoryTitle>아이디</CategoryTitle>

--- a/src/pages/Auth/SignUp.tsx
+++ b/src/pages/Auth/SignUp.tsx
@@ -22,7 +22,7 @@ const SignUp = () => {
   const [result, setResult] = useState('');
 
   return (
-    <Main className="signUpMain">
+    <Main>
       <Div>
         <img src="/logo_fincok.png" style={{ margin: '20px auto' }} />
       </Div>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,7 +1,154 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { TiHeartOutline, TiHeart } from 'react-icons/ti';
+import { IoMdArrowRoundBack } from 'react-icons/io';
+import { FcSalesPerformance } from 'react-icons/fc';
+import { FcMoneyTransfer } from 'react-icons/fc';
 
 const Detail = () => {
-  return <>Detail</>;
+  // redux로 추후 관심상품 상태관리 변경
+  const [likeState, setLikeState] = useState<boolean>(false);
+  // 컬러차트도 헤더에 똑같이 적용하기
+  const bgColor: Array<string> = ['#4D9FEB', '#33B155', '#D1B311', '#A985D8', '#979797', '#D06BB4'];
+  const tagColor: Array<string> = [
+    '#0C216F',
+    '#09551A',
+    '#645508',
+    '#601783',
+    '#2F2F2F',
+    '#660936',
+  ];
+  const colorIndex: number = Math.floor(Math.random() * bgColor.length);
+  const setColor: object = { backgroundColor: bgColor[colorIndex] };
+  const setDeepColor: object = { backgroundColor: tagColor[colorIndex] };
+  const heartStyle: object = {
+    backgroundColor: '#fff',
+    width: '35px',
+    height: '35px',
+    cursor: 'pointer',
+    borderRadius: '20px',
+    padding: '5px',
+  };
+  const iconStyle: object = {
+    width: '45px',
+    height: '45px',
+    cursor: 'pointer',
+    padding: '10px',
+    backgroundColor: '#fff',
+    borderRadius: '50px',
+  };
+
+  return (
+    <main>
+      <ColoredSection style={setColor}>
+        <div style={{ padding: '10px 0 0 10px' }}>
+          <IoMdArrowRoundBack
+            onClick={() => history.back()}
+            style={{
+              cursor: 'pointer',
+              backgroundColor: '#fff',
+              width: '15px',
+              height: '15px',
+              padding: '10px',
+              borderRadius: '100%',
+            }}
+          />
+        </div>
+        <H1>
+          <span>신한</span> <br /> <span>신한 플러스 아무튼 적금</span>
+        </H1>
+        <TagDiv>
+          {/* 옵셔널체이닝으로 응답값에 태그 있을 경우에만 */}
+          <Tag style={setDeepColor}>상품종류</Tag>
+          <Tag style={setDeepColor}>지역</Tag>
+          <Tag style={setDeepColor}>직종</Tag>
+        </TagDiv>
+        <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+          <ColDiv>
+            <FcMoneyTransfer style={iconStyle} />
+            {/* 상품별 응답값에 따라 텍스트 내용 변경 */}
+            <SummaryTitle>최고우대금리</SummaryTitle>
+            <SummaryContent>연 9.00%</SummaryContent>
+            <SummaryTitle>(12개월 세전)</SummaryTitle>
+          </ColDiv>
+          <ColDiv>
+            <FcSalesPerformance style={iconStyle} />
+            <SummaryTitle>저축한도</SummaryTitle>
+            {/* 응답값 null이면 `없음` 표시*/}
+            <SummaryContent>월 30만원</SummaryContent>
+          </ColDiv>
+        </div>
+        <Heart>
+          {likeState ? (
+            <TiHeart style={heartStyle} onClick={() => setLikeState(!likeState)} />
+          ) : (
+            <TiHeartOutline style={heartStyle} onClick={() => setLikeState(!likeState)} />
+          )}
+        </Heart>
+      </ColoredSection>
+      <FlatSection>상세설명</FlatSection>
+    </main>
+  );
 };
 
+const ColoredSection = styled.section`
+  height: 500px;
+  position: relative;
+`;
+const FlatSection = styled.section`
+  text-align: center;
+  padding-top: 30px;
+`;
+const H1 = styled.h1`
+  font-size: 30px;
+  margin-top: 0;
+  padding-bottom: 30px;
+  text-align: center;
+  color: #fff;
+  line-height: 40px;
+`;
+const TagDiv = styled.div`
+  height: 60px;
+  magin: 20px 0;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+`;
+const Tag = styled.div`
+  width: 110px;
+  height: 30px;
+  line-height: 30px;
+  color: #ececec;
+  font-size: 15px;
+  font-weight: 500;
+  border-radius: 50px;
+  text-align: center;
+`;
+const Heart = styled.div`
+  width: 80px;
+  height: 80px;
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  color: #f74440;
+`;
+const ColDiv = styled.div`
+  margin: 20px 0;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+`;
+const SummaryTitle = styled.span`
+  color: #e5e5e5;
+  margin-top: 10px;
+`;
+const SummaryContent = styled.span`
+  color: #fff;
+  font-size: 20px;
+  font-weight: 600;
+  margin-top: 10px;
+`;
 export default Detail;

--- a/src/style/globalStyles.tsx
+++ b/src/style/globalStyles.tsx
@@ -36,7 +36,7 @@ const GlobalStyles = createGlobalStyle`
   }
   h1 {
     font-size: 35px;
-    margin: 30px 0 0 5px;
+    margin: 30px 0 0;
     font-weight: 600;
   }
   ul, li {


### PR DESCRIPTION
## 작업 개요 (#18 )

## 작업 내용 (변경 사항)
- API 폴더 / 로그인 API 테스트 코드 추가
- 상품 상세페이지 상단 UI 구성
- 프리티어 설정 변경 (printWidth: 80 -> 100)

## 스크린샷
![image](https://user-images.githubusercontent.com/106734517/219360471-b86c0d01-5766-43a0-8866-bfe9e8c8862a.png)

## 리뷰 요청 사항
-  색상 지정 코드가 너무 긴 것 같은데 util 폴더로 옮기는게 나을까요?